### PR TITLE
2 space indents for JavaScript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_size = 2
 
 # JS files
 [*.js]
-indent_size = 4
+indent_size = 2
 
 # The indent size used in the `package.json` file cannot be changed
 # https://github.com/npm/npm/pull/3180#issuecomment-16336516


### PR DESCRIPTION
This seems to be a more common format for JavaScript at Te Papa and generally in the community.